### PR TITLE
Make `operationName` & `variables` optional

### DIFF
--- a/lib/apollo_socket/absinthe_message_handler.ex
+++ b/lib/apollo_socket/absinthe_message_handler.ex
@@ -13,8 +13,9 @@ defmodule ApolloSocket.AbsintheMessageHandler do
 
   @impl ApolloSocket.MessageHandler
   def handle_start(apollo_socket, operation_id, operation_name, graphql_doc, variables, opts) do
-    absinthe_opts = [variables: variables, context: %{pubsub: opts[:pubsub]}]
+    absinthe_opts = [context: %{pubsub: opts[:pubsub]}]
     |> add_operation_name(operation_name)
+    |> add_variables(variables)
 
     result = Absinthe.run(graphql_doc, opts[:schema], absinthe_opts)
 
@@ -53,6 +54,9 @@ defmodule ApolloSocket.AbsintheMessageHandler do
 
   defp add_operation_name(opts, nil), do: opts
   defp add_operation_name(opts, name), do: Keyword.put(opts, :operation_name, name)
+
+  defp add_variables(opts, nil), do: opts
+  defp add_variables(opts, variables), do: Keyword.put(opts, :variables, variables)
 
   defp messages_for_result(operation_id, query_response) when is_map(query_response) do
     [

--- a/lib/apollo_socket/message_handler.ex
+++ b/lib/apollo_socket/message_handler.ex
@@ -25,11 +25,9 @@ defmodule ApolloSocket.MessageHandler do
 
   @doc false
   def handle_message(module, apollo_socket, %OperationMessage{ type: :gql_start, id: operation_id} = message, opts) do
-    %{
-      "operationName" => operation_name,
-      "variables" => variables,
-      "query" => graphql_doc,
-    } = message.payload
+    %{ "query" => graphql_doc } = message.payload
+    operation_name = message.payload["operationName"]
+    variables = message.payload["variables"]
 
     module.handle_start(apollo_socket, operation_id, operation_name, graphql_doc, variables, opts)
   end


### PR DESCRIPTION
Update `start` messages' `operationName` and `variables` payload fields to be optional.

This should be consistent with what is outlined in the [latest version of the spec at the time of this PR](https://github.com/apollographql/subscriptions-transport-ws/blob/dbcf2d8e1400158e62de2ff3ae97dd98916cd4bc/PROTOCOL.md)