### PR TITLE
Phoenix 1.4 Socket (WIP)

### DIFF
--- a/lib/apollo_socket/absinthe_message_handler.ex
+++ b/lib/apollo_socket/absinthe_message_handler.ex
@@ -38,7 +38,7 @@ defmodule ApolloSocket.AbsintheMessageHandler do
   end
 
   @impl ApolloSocket.MessageHandler
-  def handle_stop(apollo_socket, operation_id, opts) do
+  def handle_stop(_apollo_socket, operation_id, opts) do
     data_broker_pids =
       opts.broker_processes
       |> Enum.filter(&(elem(&1, 0) == operation_id))
@@ -59,7 +59,7 @@ defmodule ApolloSocket.AbsintheMessageHandler do
   end
 
   @impl ApolloSocket.MessageHandler
-  def handle_info(apollo_socket, {:data_broker_started, operation_id, pid}, opts) do
+  def handle_info(_apollo_socket, {:data_broker_started, operation_id, pid}, opts) do
     new_opts = %{opts | broker_processes: [{operation_id, pid} | opts.broker_processes]}
     {:ok, new_opts}
   end

--- a/lib/apollo_socket/cowboy_socket_handler.ex
+++ b/lib/apollo_socket/cowboy_socket_handler.ex
@@ -28,6 +28,12 @@ defmodule ApolloSocket.CowboySocketHandler do
     {:reply, [{:text, json_string}], request, state}
   end
 
+  # this handler forwards an info message onto the message handler module
+  def websocket_info({:message_handler, message}, request, %{apollo_socket: apollo_socket}) do
+    {:ok, apollo_socket} = ApolloSocket.handle_message_handler_info(apollo_socket, message)
+    {:ok, request, %{apollo_socket: apollo_socket}}
+  end
+
   # generic message handler does nothing
   def websocket_info(message, request, state) do
     Logger.debug("CowboySocketHandler.websocket_info with message #{inspect message}")

--- a/lib/apollo_socket/data_broker.ex
+++ b/lib/apollo_socket/data_broker.ex
@@ -76,6 +76,8 @@ defmodule ApolloSocket.DataBroker do
     send_data_result(proc_message, state)
   end
 
+  def handle_info(_, state), do: {:noreply, state}
+
   defp send_data_result(proc_message, state) when is_map(proc_message) do
     op_message = data_message_for_result(state.operation_id, proc_message)
     ApolloSocket.send_message(state.apollo_socket, op_message)

--- a/lib/apollo_socket/data_broker.ex
+++ b/lib/apollo_socket/data_broker.ex
@@ -50,7 +50,7 @@ defmodule ApolloSocket.DataBroker do
       }}
   end
 
-  def terminate(reason, state) do
+  def terminate(_reason, state) do
     Logger.debug("Tearing down data broker, got shutdown signal")
     Absinthe.Subscription.unsubscribe(state.pubsub, state.absinthe_id)
     :normal

--- a/lib/apollo_socket/data_broker.ex
+++ b/lib/apollo_socket/data_broker.ex
@@ -18,6 +18,7 @@ defmodule ApolloSocket.DataBroker do
     :pubsub, 
     :absinthe_id, 
     :operation_id,
+    :init_callback,
   ]
 
   def start_link(options) do
@@ -32,6 +33,7 @@ defmodule ApolloSocket.DataBroker do
 
     subscribe_to_data(pubsub, absinthe_id)
     monitor_id = monitor_websocket(ApolloSocket.websocket(apollo_socket))
+    call_init_callback(Keyword.get(options, :init_callback), options)
 
     {:ok, %{
       apollo_socket: apollo_socket,
@@ -84,5 +86,11 @@ defmodule ApolloSocket.DataBroker do
   def monitor_websocket(nil), do: raise "#__MODULE__ requires the pid of the hosting websocket"
   def monitor_websocket(socket) do
     Process.monitor(socket)    
+  end
+
+  defp call_init_callback(nil, _opts), do: :ok
+  defp call_init_callback(callback, opts) do
+    callback.(opts)
+    :ok
   end
 end

--- a/lib/apollo_socket/message_handler.ex
+++ b/lib/apollo_socket/message_handler.ex
@@ -13,6 +13,7 @@ defmodule ApolloSocket.MessageHandler do
   @callback handle_connection_init(apollo_socket, map(), message_handler_opts) :: message_handler_result
   @callback handle_start(apollo_socket, String.t, String.t, String.t, map(), message_handler_opts) :: message_handler_result
   @callback handle_stop(apollo_socket, String.t, message_handler_opts) :: message_handler_result
+  @callback handle_info(apollo_socket, any(), message_handler_opts) :: message_handler_result
 
   def handle_connection_init(_module, _apollo_socket, _connection_params, opts) do
     {:reply, OperationMessage.new_connection_ack(), opts }
@@ -60,6 +61,11 @@ defmodule ApolloSocket.MessageHandler do
       @impl true
       def handle_stop(_apollo_socket, _operation_id, opts) do
         { :ok, opts }
+      end
+
+      @impl true
+      def handle_info(_apollo_socket, _message, opts) do
+        {:ok, opts}
       end
 
       def handle_message(apollo_socket, %OperationMessage{} = message, opts), do:

--- a/lib/phoenix/endpoint.ex
+++ b/lib/phoenix/endpoint.ex
@@ -1,0 +1,57 @@
+# Adapted from https://github.com/absinthe-graphql/absinthe_phoenix/blob/86e77a1ec23043557e89997da04a445ac4d7e5c3/lib/absinthe/phoenix/endpoint.ex
+
+defmodule ApolloSocket.Phoenix.Endpoint do
+  defmacro __using__(_) do
+    quote do
+      @behaviour Absinthe.Subscription.Pubsub
+      @before_compile unquote(__MODULE__)
+    end
+  end
+
+  defmacro __before_compile__(_) do
+    quote do
+      def node_name() do
+        ApolloSocket.Phoenix.Endpoint.node_name(@otp_app, __MODULE__)
+      end
+      def publish_mutation(topic, mutation_result, subscribed_fields) do
+        ApolloSocket.Phoenix.Endpoint.publish_mutation(@otp_app, __MODULE__, topic, mutation_result, subscribed_fields)
+      end
+      def publish_subscription(topic, data) do
+        ApolloSocket.Phoenix.Endpoint.publish_subscription(@otp_app, __MODULE__, topic, data)
+      end
+    end
+  end
+
+  @doc false
+  def node_name(otp_app, endpoint) do
+    pubsub = pubsub(otp_app, endpoint)
+
+    Phoenix.PubSub.node_name(pubsub)
+  end
+
+  @doc false
+  def publish_subscription(otp_app, endpoint, topic, result) do
+    pubsub = pubsub(otp_app, endpoint)
+    Phoenix.PubSub.broadcast(pubsub, topic, result)
+  end
+
+  @doc false
+  def publish_mutation(otp_app, endpoint, proxy_topic, mutation_result, subscribed_fields) do
+    pubsub = pubsub(otp_app, endpoint)
+
+    message = %{
+      node: node_name(otp_app, endpoint),
+      subscribed_fields: subscribed_fields,
+      mutation_result: mutation_result,
+    }
+
+    Phoenix.PubSub.broadcast(pubsub, proxy_topic, message)
+  end
+
+  defp pubsub(otp_app, endpoint) do
+    Application.get_env(otp_app, endpoint)[:pubsub][:name] || raise """
+    Pubsub needs to be configured for #{inspect otp_app} #{inspect endpoint}!
+    """
+  end
+end
+

--- a/lib/phoenix/socket.ex
+++ b/lib/phoenix/socket.ex
@@ -1,0 +1,59 @@
+defmodule ApolloSocket.Phoenix.Socket do
+  require Logger
+  @behaviour Phoenix.Socket.Transport
+
+  alias ApolloSocket.Phoenix.BrokerSupervisor, as: BrokerSupervisor
+
+  def child_spec(opts) do
+    DynamicSupervisor.child_spec(strategy: :one_for_one, name: BrokerSupervisor)
+  end
+
+  def connect(map) do
+    # Callback to retrieve relevant data from the connection.
+    # The map contains options, params, transport and endpoint keys.
+    Logger.debug("GraphqlSocket.connect #{inspect map}")
+    {:ok, %{endpoint: map.endpoint, schema: Keyword.get(map.options, :schema)}}
+  end
+
+  def init(%{endpoint: endpoint, schema: schema}) do
+    message_handler_opts = [
+      schema: schema,
+      pubsub: endpoint,
+      broker_sup: BrokerSupervisor
+    ]
+    apollo_socket = ApolloSocket.new(websocket: self(),
+                                     message_handler: ApolloSocket.AbsintheMessageHandler,
+                                     message_handler_opts: message_handler_opts)
+    {:ok, %{apollo_socket: apollo_socket}}
+  end
+
+  def handle_in({body, _opts}, %{apollo_socket: apollo_socket}) do
+    {:ok, apollo_socket} = ApolloSocket.handle_json_message(apollo_socket, body)
+    {:ok, %{apollo_socket: apollo_socket}}
+  end
+
+  def handle_in({message, _opts}, state) do
+    Logger.debug("GraphqlSocket.handle_in unexpected message: #{message}")
+    {:ok, state}
+  end
+
+  def handle_info({:send_json, json_string}, state) do
+    {:push, {:text, json_string}, state}
+  end
+
+  def handle_info({:message_handler, message}, %{apollo_socket: apollo_socket}) do
+    {:ok, apollo_socket} = ApolloSocket.handle_message_handler_info(apollo_socket, message)
+    {:ok, %{apollo_socket: apollo_socket}}
+  end
+
+  def handle_info(message, state) do
+    Logger.debug("GraphqlSocket.handle_info with message #{inspect message}")
+    {:ok, state}
+  end
+
+  def terminate(_reason, _state) do
+    Logger.debug("GraphqlSocket.terminate")
+    :ok
+  end
+end
+

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,8 @@ defmodule ApolloSocket.MixProject do
     [
       {:absinthe, "~> 1.4"},
       {:jason, "~> 1.0"},
-      {:phoenix_pubsub, "~> 1.0"}
+      {:phoenix_pubsub, "~> 1.0"},
+      {:phoenix, "~> 1.4.0-rc", override: true}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,8 @@
 %{
   "absinthe": {:hex, :absinthe, "1.4.10", "9f8d0c34dfcfd0030d3a3f123c7501e99ab59651731387289dad5885047ebb2a", [:mix], [{:dataloader, "~> 1.0.0", [hex: :dataloader, repo: "hexpm", optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
-  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.0.2", "bfa7fd52788b5eaa09cb51ff9fcad1d9edfeb68251add458523f839392f034c1", [:mix], [], "hexpm"},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
+  "phoenix": {:hex, :phoenix, "1.4.0-rc.1", "f27f72c5e617f25a94d30273e3c156bc82418b450a9987664b821d6af80e74c2", [:mix], [{:cowboy, "~> 1.0 or ~> 2.5", [hex: :cowboy, repo: "hexpm", optional: true]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}, {:phoenix_pubsub, "~> 1.1", [hex: :phoenix_pubsub, repo: "hexpm", optional: false]}, {:plug, "~> 1.6.4 or ~> 1.7", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
+  "phoenix_pubsub": {:hex, :phoenix_pubsub, "1.1.0", "d55e25ff1ff8ea2f9964638366dfd6e361c52dedfd50019353598d11d4441d14", [:mix], [], "hexpm"},
+  "plug": {:hex, :plug, "1.6.4", "35618dd2cc009b69b000f785452f6b370f76d099ece199733fea27bc473f809d", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
 }


### PR DESCRIPTION
### Builds off of #2, diff for this PR is https://github.com/easco/absinthe_apollo_sockets/compare/b9309a9^...darrenclark:phoenix-1.4


The [Phoenix project did an overhaul of the Socket <-> Transport contract in the upcoming 1.4 release](https://github.com/phoenixframework/phoenix/blob/57883999d68be0d1d9ef89bab9ba9efa659c3a00/CHANGELOG.md#the-socket---transport-contract).  One particular part of interest was:

> For example, if you would like to have direct control of the socket and bypass the channel implementation completely, it is now very straight-forward to do so.

I hacked together a proof of concept (95c5823), implementing a `Socket`.  Basic gist of it (usage wise) is:

1. Add Absinthe.Subscription supervisor to `application.ex`:
```elixir
# ... rest of file ...
supervisor(MyAppWeb.Endpoint, []),
supervisor(Absinthe.Subscription, [MyAppWeb.Endpoint])
# ... rest of file ...
```

2. Update `endpoint.ex` to:
  - use `ApolloSocket.Phoenix.Endpoint`
  - add a `ApolloSocket.Phoenix.Socket`, passing along your Absinthe schema

  ```elixir
  defmodule MyAppWeb.Endpoint do
    use Phoenix.Endpoint, otp_app: :my_app
    use ApolloSocket.Phoenix.Endpoint

    socket "/ws-graphql", ApolloSocket.Phoenix.Socket,
      websocket: [schema: MyAppWeb.Schema]

  # ... rest of file ...
  ```

---

@easco Wanted to get your thoughts on this.. 

Would this be something that should live in this repo?

It would introduce a dependency on `phoenix` (at least 1.4 in this case), so I'm not sure if it makes sense in here (or if it should be a separate repo that includes `absinthe_apollo_sockets`)