### PR TITLE
feat: Set port and path options in environment variables for example applications

### DIFF
--- a/examples/apollo_cowboy/README.md
+++ b/examples/apollo_cowboy/README.md
@@ -18,4 +18,21 @@ Two options can be set through environment variables:
   that handles the GraphQL queries, mutations and subscriptions.  The default
   is "websocket", meaning that you would connect using the url:
 
-  `ws://localhost:8080/socket/websocket`
+  ws://localhost:8080/socket/websocket
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `apollo_cowboy` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:apollo_cowboy, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/apollo_cowboy](https://hexdocs.pm/apollo_cowboy).

--- a/examples/apollo_cowboy/README.md
+++ b/examples/apollo_cowboy/README.md
@@ -1,21 +1,21 @@
 # ApolloCowboy
 
-**TODO: Add description**
+Example of ApolloSocket running on a cowboy webserver, without any Phoenix
+dependencies other than the Phoenix.PubSub system.
 
-## Installation
+To start the cowboy server:
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `apollo_cowboy` to your list of dependencies in `mix.exs`:
+  * Install dependencies with `mix deps.get`
+  * Install Node.js dependencies with `npm install` inside the `assets` directory
+  * Start Phoenix endpoint with `mix run --no-halt`
 
-```elixir
-def deps do
-  [
-    {:apollo_cowboy, "~> 0.1.0"}
-  ]
-end
-```
+Two options can be set through environment variables:
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/apollo_cowboy](https://hexdocs.pm/apollo_cowboy).
+`PORT` will set the port that cowboy listens on. 
+  The default is 8080.
 
+`APOLLO_SOCKET_PATH` will set the path (under "socket/") for the websocket
+  that handles the GraphQL queries, mutations and subscriptions.  The default
+  is "websocket", meaning that you would connect using the url:
+
+  `ws://localhost:8080/socket/websocket`

--- a/examples/apollo_cowboy/README.md
+++ b/examples/apollo_cowboy/README.md
@@ -7,7 +7,7 @@ To start the cowboy server:
 
   * Install dependencies with `mix deps.get`
   * Install Node.js dependencies with `npm install` inside the `assets` directory
-  * Start Phoenix endpoint with `mix run --no-halt`
+  * Start dev server with `mix run --no-halt`
 
 Two options can be set through environment variables:
 

--- a/examples/apollo_cowboy/lib/apollo_cowboy/application.ex
+++ b/examples/apollo_cowboy/lib/apollo_cowboy/application.ex
@@ -1,5 +1,10 @@
-defmodule ApolloCowboyExample do
+defmodule ApolloCowboyExample.Application do
+  use Application
+
   def start(_mode, _args) do
+    # Read port and socket_path from environment variables
+    {port, socket_path} = get_environment_args()
+
     # Define the router for cowboy that includes a socket handler
     # for the apollo sockets and a couple of static handlers
     # that serve up the example website.
@@ -8,7 +13,7 @@ defmodule ApolloCowboyExample do
         {:_,
          [
            {"/", :cowboy_static, {:priv_file, :apollo_cowboy, "static/index.html"}},
-           {"/socket/websocket", ApolloSocket.CowboySocketHandler,
+           {"/socket/#{socket_path}", ApolloSocket.CowboySocketHandler,
             {
               ApolloSocket.AbsintheMessageHandler,
               schema: ApolloCowboyExample.Schema,
@@ -21,14 +26,14 @@ defmodule ApolloCowboyExample do
 
     children = [
       # This is the supervisor that provides a set of counters in the schema
-      {ApolloCowboyExample.Counter, []},
+      ApolloCowboyExample.Counter,
 
       # Absinthe uses a PubSub system to handle subscriptions.
       # Ours is built on top of Phoenix PubSub so we create that
-      {Phoenix.PubSub, [adapter_name: Phoenix.PubSub.PG2, name: ApolloCowboyExample.PubSub]},
+      {Phoenix.PubSub, name: ApolloCowboyExample.PubSub},
 
       # This is the Absinthe PubSub that makes use of the Phoenix Pubsub
-      absinthe_subscriptions(ApolloCowboyExample.Absinthe.PubSub),
+      {Absinthe.Subscription, ApolloCowboyExample.Absinthe.PubSub},
 
       # When a subscription is created we create an intermediary process that
       # translates from the Absinthe PubSub to the Apollo socket protocol
@@ -36,30 +41,27 @@ defmodule ApolloCowboyExample do
       {DynamicSupervisor, strategy: :one_for_one, name: ApolloCowboyExample.BrokerSupervisor},
 
       # And we start the web server, on port 8080
-      cowboy_server(8080, dispatch)
+      cowboy_server(port, dispatch)
     ]
 
-    # The supervisor is named just to make it easy to pick out in observer
-    Supervisor.start_link(
-      children,
-      strategy: :one_for_one,
-      name: ApolloCowboyExampleSupervisor
-    )
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: ApolloCowboyExample.Supervisor]
+    Supervisor.start_link(children, opts)
   end
 
-  def absinthe_subscriptions(name) do
-    %{
-      type: :supervisor,
-      id: Absinthe.Subscription,
-      start: {Absinthe.Subscription, :start_link, [name]}
-    }
-  end
-
-  def cowboy_server(port, dispatch) do
+  defp cowboy_server(port, dispatch) do
     %{
       type: :supervisor,
       id: :cowboy,
       start: {:cowboy, :start_clear, [:http_server, [port: port], %{env: %{dispatch: dispatch}}]}
     }
+  end
+
+  # Read PORT and APOLLO_SOCKET_PATH environment variables or defaults
+  defp get_environment_args() do
+    port = System.get_env("PORT", "8080") |> String.to_integer()
+    socket_path = System.get_env("APOLLO_SOCKET_PATH", "websocket")
+    {port, socket_path}
   end
 end

--- a/examples/apollo_cowboy/mix.exs
+++ b/examples/apollo_cowboy/mix.exs
@@ -14,7 +14,7 @@ defmodule ApolloCowboy.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      mod: {ApolloCowboyExample, []},
+      mod: {ApolloCowboyExample.Application, []},
       extra_applications: [:logger]
     ]
   end

--- a/examples/phoenix_sample/README.md
+++ b/examples/phoenix_sample/README.md
@@ -15,7 +15,7 @@ that handles the GraphQL queries, mutations and subscriptions.
 The value for the variable should be different than "websocket",
 which Phoenix reserves for its channels.
 
-The default is "apollo_socket", meaning that you would connect using 
+The default is "apollo_socket", meaning that you would connect using
 the URL:
 
 ws://localhost:4000/socket/apollo_socket

--- a/examples/phoenix_sample/README.md
+++ b/examples/phoenix_sample/README.md
@@ -6,19 +6,19 @@ To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`
   * Install Node.js dependencies with `npm install` inside the `assets` directory
-  * Start Phoenix endpoint with `mix phx.server`
+  * Start Phoenix endpoint with `mix phx.server`, optionally after setting
+    the Apollo socket path environment variable as described here.
 
-Two options can be set through environment variables:
+Set the operating system environment variable `APOLLO_SOCKET_PATH`
+to configure the path (under "socket/") for the Apollo websocket
+that handles the GraphQL queries, mutations and subscriptions.
+The value for the variable should be different than "websocket",
+which Phoenix reserves for its channels.
 
-`PORT` will set the port that the server listens on. 
-  The default is 4000.
+The default is "apollo_socket", meaning that you would connect using 
+the URL:
 
-`APOLLO_SOCKET_PATH` will set the path (under "socket/") for the websocket
-  that handles the GraphQL queries, mutations and subscriptions. It
-  should be different than "websocket", which Phoenix uses for channels.
-  The default is "apollo_socket", meaning that you would connect using the url:
-
-  `ws://localhost:4000/socket/apollo_socket`
+ws://localhost:4000/socket/apollo_socket
 
 Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
 

--- a/examples/phoenix_sample/README.md
+++ b/examples/phoenix_sample/README.md
@@ -1,12 +1,24 @@
 # PhoenixSample
 
+Example of ApolloSocket running on a Phoenix server.
+
 To start your Phoenix server:
 
   * Install dependencies with `mix deps.get`
   * Install Node.js dependencies with `npm install` inside the `assets` directory
   * Start Phoenix endpoint with `mix phx.server`
 
-Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
+Two options can be set through environment variables:
+
+`PORT` will set the port that the server listens on. 
+  The default is 4000.
+
+`APOLLO_SOCKET_PATH` will set the path (under "socket/") for the websocket
+  that handles the GraphQL queries, mutations and subscriptions. It
+  should be different than "websocket", which Phoenix uses for channels.
+  The default is "apollo_socket", meaning that you would connect using the url:
+
+  `ws://localhost:4000/socket/apollo_socket`
 
 Ready to run in production? Please [check our deployment guides](https://hexdocs.pm/phoenix/deployment.html).
 

--- a/examples/phoenix_sample/config/config.exs
+++ b/examples/phoenix_sample/config/config.exs
@@ -7,6 +7,8 @@
 # General application configuration
 use Mix.Config
 
+socket_path = System.get_env("APOLLO_SOCKET_PATH", "apollo_socket")
+
 # Configures the endpoint
 config :phoenix_sample, PhoenixSampleWeb.Endpoint,
   url: [host: "localhost"],
@@ -19,7 +21,7 @@ config :phoenix_sample, PhoenixSampleWeb.Endpoint,
   # ahead of the Phoenix endpoint adapter.
   http: [dispatch: [
           {:_, [
-              {"/socket/apollo_socket", ApolloSocket.CowboySocketHandler,
+              {"/socket/#{socket_path}", ApolloSocket.CowboySocketHandler,
                 { # ApolloSocket configuration settings
                   ApolloSocket.AbsintheMessageHandler,
                   schema: PhoenixSample.Schema,

--- a/examples/phoenix_sample/config/dev.exs
+++ b/examples/phoenix_sample/config/dev.exs
@@ -7,7 +7,7 @@ use Mix.Config
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :phoenix_sample, PhoenixSampleWeb.Endpoint,
-  http: [port: 4000],
+  http: [port: System.get_env("PORT", "4000") |> String.to_integer()],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/examples/phoenix_sample/config/dev.exs
+++ b/examples/phoenix_sample/config/dev.exs
@@ -7,7 +7,7 @@ use Mix.Config
 # watchers to your application. For example, we use it
 # with webpack to recompile .js and .css sources.
 config :phoenix_sample, PhoenixSampleWeb.Endpoint,
-  http: [port: System.get_env("PORT", "4000") |> String.to_integer()],
+  http: [port: 4000],
   debug_errors: true,
   code_reloader: true,
   check_origin: false,

--- a/examples/phoenix_sample/lib/phoenix_sample/application.ex
+++ b/examples/phoenix_sample/lib/phoenix_sample/application.ex
@@ -16,6 +16,9 @@ defmodule PhoenixSample.Application do
       # Start the PubSub system
       {Phoenix.PubSub, name: PhoenixSample.PubSub},
 
+      # Start the Endpoint (http/https)
+      PhoenixSampleWeb.Endpoint,
+
       # Start and Absinthe Subscription pointed at our adapter module
       # that translates from Absinthe related notifications to
       # the Phoenix PubSub system started above
@@ -24,10 +27,7 @@ defmodule PhoenixSample.Application do
       # When a subscription is created we create an intermediary process that
       # translates from the Absinthe PubSub to the Apollo socket protocol
       # This supervisor watches those subscriptions.
-      {DynamicSupervisor, strategy: :one_for_one, name: PhoenixSample.BrokerSupervisor},
-
-      # Start the Endpoint (http/https)
-      PhoenixSampleWeb.Endpoint
+      {DynamicSupervisor, strategy: :one_for_one, name: PhoenixSample.BrokerSupervisor}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/examples/phoenix_sample/lib/phoenix_sample/application.ex
+++ b/examples/phoenix_sample/lib/phoenix_sample/application.ex
@@ -8,7 +8,7 @@ defmodule PhoenixSample.Application do
   def start(_type, _args) do
     children = [
       # This is the supervisor that provides a set of counters in the schema
-      {PhoenixSample.Counter, []},
+      PhoenixSample.Counter,
 
       # Start the Telemetry supervisor
       PhoenixSampleWeb.Telemetry,
@@ -19,7 +19,7 @@ defmodule PhoenixSample.Application do
       # Start and Absinthe Subscription pointed at our adapter module
       # that translates from Absinthe related notifications to
       # the Phoenix PubSub system started above
-      {Absinthe.Subscription, [PhoenixSample.Absinthe.PubSub]},
+      {Absinthe.Subscription, PhoenixSample.Absinthe.PubSub},
 
       # When a subscription is created we create an intermediary process that
       # translates from the Absinthe PubSub to the Apollo socket protocol

--- a/examples/phoenix_sample/lib/phoenix_sample/application.ex
+++ b/examples/phoenix_sample/lib/phoenix_sample/application.ex
@@ -16,18 +16,18 @@ defmodule PhoenixSample.Application do
       # Start the PubSub system
       {Phoenix.PubSub, name: PhoenixSample.PubSub},
 
+      # When a subscription is created we create an intermediary process that
+      # translates from the Absinthe PubSub to the Apollo socket protocol
+      # This supervisor watches those subscriptions.
+      {DynamicSupervisor, strategy: :one_for_one, name: PhoenixSample.BrokerSupervisor},
+
       # Start the Endpoint (http/https)
       PhoenixSampleWeb.Endpoint,
 
       # Start and Absinthe Subscription pointed at our adapter module
       # that translates from Absinthe related notifications to
       # the Phoenix PubSub system started above
-      {Absinthe.Subscription, PhoenixSample.Absinthe.PubSub},
-
-      # When a subscription is created we create an intermediary process that
-      # translates from the Absinthe PubSub to the Apollo socket protocol
-      # This supervisor watches those subscriptions.
-      {DynamicSupervisor, strategy: :one_for_one, name: PhoenixSample.BrokerSupervisor}
+      {Absinthe.Subscription, PhoenixSample.Absinthe.PubSub}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/apollo_socket/data_broker.ex
+++ b/lib/apollo_socket/data_broker.ex
@@ -4,7 +4,6 @@ defmodule ApolloSocket.DataBroker do
   alias ApolloSocket.OperationMessage
 
   require Logger
-  require IEx
 
   @moduledoc """
   This module implements a GenServer that sits as an intermediary between


### PR DESCRIPTION
Adds support for setting the listening port and the websocket URL path via environment variables.

Also aligns both examples' application start up in an Application module, and adds some simple start instructions in their README files.